### PR TITLE
Fix .launch icon alignment in demos

### DIFF
--- a/HEAD/demo-partials/button/demoBasicUsage/style.css
+++ b/HEAD/demo-partials/button/demoBasicUsage/style.css
@@ -16,5 +16,3 @@
   left: 7px;
   font-size: 14px;
   opacity: 0.54; }
-.buttondemoBasicUsage .launch {
-  padding-top: 12px; }


### PR DESCRIPTION
fixes .launch icon alignment on demo page currently applied to the disabled icon button. Image attached.

![launch](https://cloud.githubusercontent.com/assets/6006148/9412600/2fae5f42-47f2-11e5-921b-71bd7be0ce8e.JPG)
